### PR TITLE
feat: Expose Math Delimiter

### DIFF
--- a/src/interpreter/quiz.ts
+++ b/src/interpreter/quiz.ts
@@ -34,6 +34,7 @@ import {
   Feedback,
   FeedbackItem,
   QuizOptions,
+  InlineMathDelimiter,
 } from '../types';
 //import { MatrixInput } from './matinput';
 //import { getHtmlChildElementRecursive } from './help';
@@ -341,8 +342,16 @@ export class SellQuiz {
     }*/
 
   importQuestion(src: string, params?: QuizOptions): boolean {
-    const { latex = false, codeStartRow = 0 } = params;
+    const {
+      latex = false,
+      codeStartRow = 0,
+      inlineMathStartDelimiter = InlineMathDelimiter.tick,
+      inlineMathEndDelimiter = InlineMathDelimiter.tick,
+    } = params;
     this.latexMode = latex;
+
+    this.inlineMathStartDelimiter = inlineMathStartDelimiter;
+    this.inlineMathEndDelimiter = inlineMathEndDelimiter;
 
     this.resizableRows = false;
     this.resizableCols = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,14 +2,24 @@ export enum VariableType {
   Boolean = 'BOOLEAN',
   Scalar = 'SCALAR',
   Text = 'TEXT',
-  Unimplemented = 'UNIMPLEMENTED'
+  Unimplemented = 'UNIMPLEMENTED',
 }
 
 export enum InputType {
   Checkbox = 'CHECKBOX',
   Radiobutton = 'RADIOBUTTON',
   Textfield = 'TEXTFIELD',
-  Unimplemented = 'UNIMPLEMENTED'
+  Unimplemented = 'UNIMPLEMENTED',
+}
+
+export enum InlineMathDelimiter {
+  tick = '`',
+  backSlashStart = '\\(',
+  backSlashEnd = '\\)',
+  texStart = '[tex]',
+  texEnd = '[/tex]',
+  spanStart = '<span class = math>',
+  spanEnd = '</span>',
 }
 
 export interface Question {
@@ -38,7 +48,7 @@ export interface Answer {
 export interface Input {
   name: string;
   type: InputType;
-  width: -1;   // TODO: in pixels? yet unset
+  width: -1; // TODO: in pixels? yet unset
 }
 
 export interface Feedback {
@@ -54,4 +64,6 @@ export interface FeedbackItem {
 export interface QuizOptions {
   latex?: boolean;
   codeStartRow?: number;
+  inlineMathStartDelimiter?: InlineMathDelimiter;
+  inlineMathEndDelimiter?: InlineMathDelimiter;
 }


### PR DESCRIPTION
Auch wieder einfach den Math Delimiter per Option-Objekt setzbar gemacht.  
Es hat sich allerdings herausgestellt das ich gar nicht benötigt habe. 
Aber für die Zukunft halte ich diese Option weiterhin sinnvoll.